### PR TITLE
deactivate top menu bar when mouse leaves

### DIFF
--- a/src/components/MenuBar.vue
+++ b/src/components/MenuBar.vue
@@ -362,7 +362,7 @@ export default defineComponent({
         menuItems.value = result.navigateMenu.items;
       } else if ("navigateMenubar" in result) {
         highlightFirstElement.value = true;
-        let {
+        const {
           navigateMenubar: { nextId },
         } = result;
         activeMenuBarId.value = nextId;

--- a/src/components/MenuBar.vue
+++ b/src/components/MenuBar.vue
@@ -35,6 +35,7 @@
           :is-touch-device="isMobileDevice"
           :on-selected="handleSelected"
           :highlight-first-element="highlightFirstElement"
+          @deactivate="handleDeactivateMenu"
           @activate="handleActivateMenu"
           @activate-next="handleActivateDir"
           @activate-previous="handleActivateDir"
@@ -186,6 +187,7 @@ export default defineComponent({
         activeMenuSelection.value = -1;
         activeMenuBarId.value = "";
         highlightFirstElement.value = false;
+        handleDeactivateMenu();
       }
     };
 
@@ -303,6 +305,17 @@ export default defineComponent({
       );
     };
 
+    const handleDeactivateMenu = (id?: string) => {
+      // keep the menubar when the sub menu is being displayed
+      if (!menuActive.value) {
+        menuItems.value = menuItems.value.map((item) =>
+          Object.assign({}, item, {
+            showMenu: false,
+          })
+        );
+      }
+    };
+
     const handleOnShowMenu = (state: boolean, id: string) => {
       menuActive.value = state;
       if (state) {
@@ -374,6 +387,7 @@ export default defineComponent({
       expandClass,
       handleActivateDir,
       handleActivateMenu,
+      handleDeactivateMenu,
       handleDrag,
       handleDragCancel,
       handleDragEnd,

--- a/src/components/MenuBar.vue
+++ b/src/components/MenuBar.vue
@@ -335,6 +335,8 @@ export default defineComponent({
         dockPosition.value === DockPosition.RIGHT
       ) {
         return menuBarActive.value ? "expanded" : "not-expanded";
+      } else {
+        return "";
       }
     });
 

--- a/src/components/MenuBar.vue
+++ b/src/components/MenuBar.vue
@@ -305,7 +305,7 @@ export default defineComponent({
       );
     };
 
-    const handleDeactivateMenu = (id?: string) => {
+    const handleDeactivateMenu = () => {
       // keep the menubar when the sub menu is being displayed
       if (!menuActive.value) {
         menuItems.value = menuItems.value.map((item) =>

--- a/src/components/MenuBarItem.vue
+++ b/src/components/MenuBarItem.vue
@@ -4,7 +4,8 @@
     :class="[...menuBarStyle, 'menu-bar-item-container']"
     :style="{ background: bgColor }"
     tabindex="0"
-    @mouseenter="setMenuViewable()"
+    @mouseenter="setMenuViewable(true)"
+    @mouseleave="setMenuViewable(false)"
     @keyup="handleKeyUp"
   >
     <span
@@ -131,6 +132,7 @@ export default defineComponent({
   },
   emits: [
     "show",
+    "deactivate",
     "activate",
     "selected",
     "activate-next",
@@ -157,7 +159,13 @@ export default defineComponent({
     });
 
     // activate menu
-    const setMenuViewable = () => emit("activate", props.id);
+    const setMenuViewable = (viewable: boolean) => {
+      if (viewable) {
+        emit("activate", props.id);
+      } else {
+        emit("deactivate", props.id);
+      }
+    }
 
     // toggle menu
     const toggleMenu = (event: MouseEvent | TouchEvent) => {

--- a/src/components/MenuBarItem.vue
+++ b/src/components/MenuBarItem.vue
@@ -179,7 +179,7 @@ export default defineComponent({
     const highlightIndex = ref(-1);
 
     const computeMenuStyle = () => {
-      let newStyle: {
+      const newStyle: {
         top?: string;
         left?: string;
         right?: string;


### PR DESCRIPTION
The code left the menu item highlighted when the mouse clicked other element on the screen. This fixes the top menu item to be deactivates when the mouse leaves the menu bar and other elements are clicked.

The active menu is preserved when the mouse simply moves away from the menu, but deactivates when the mouse is clicked on other part of the screen.